### PR TITLE
Redirect to documentation by default

### DIFF
--- a/docs/Before-Start.md
+++ b/docs/Before-Start.md
@@ -5,3 +5,7 @@ When you first use Hoyo Buddy, you need to link an email and password or use tok
 But there's users that use Third-party Platform Login (i.e: Apple ID, Game Center, Google, PlayStation, Microsoft, Facebook and Twitter).
 
 This page will help you setup your HoYoverse account to use with Hoyo Buddy
+
+## As a first time player. No account yet.
+
+If this is the first time you hear about any HoYoverse games

--- a/i18n/vi/docusaurus-plugin-content-pages/index.js
+++ b/i18n/vi/docusaurus-plugin-content-pages/index.js
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   useEffect(() => {
-    window.location.href = 'https://seria.is-a.dev/hb-site/index-vi-vn.html';
+    window.location.href = './docs/intro';
   }, []);
   return null;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   useEffect(() => {
-    window.location.href = 'https://hb.seria.moe';
+    window.location.href = './docs/intro';
   }, []);
   return null;
 }


### PR DESCRIPTION
Change the default redirect on the homepage to point to the documentation instead of an external site. This improves user onboarding by directing first-time players to relevant setup information.